### PR TITLE
Added functionality to read files from folder

### DIFF
--- a/models/polynomial/NIHMS80246_S4.ode
+++ b/models/polynomial/NIHMS80246_S4.ode
@@ -1,4 +1,4 @@
-begin model NIHMS80246_S4_ode
+begin model NIHMS80246_S4
  begin parameters
   L_tot = 100
   R_tot = 100

--- a/models/polynomial/cyclin1ODE.ode
+++ b/models/polynomial/cyclin1ODE.ode
@@ -144,7 +144,8 @@ begin model cyclin1ODE
   S141
  end init
  begin partition
-  {S1,S129,S36,S54,S41,S10,S11,S78,S0,S48},  {S141}
+  {S1,S129,S36,S54,S41,S10,S11,S78,S0,S48},  
+  {S141}
  end partition
  begin ODE
   d(S0) = 0.001*S24

--- a/tests/numerical/data.json
+++ b/tests/numerical/data.json
@@ -1,4 +1,17 @@
 {
+    "CMSB2023[presentation]":{
+        "read": "polynomial",
+        "matrix": "polynomial",
+        "model": "BioNetGen_CCP",
+        "type": "analysis",
+        "mid_points": 120,
+        "observables":{
+            "D13PG": [
+                "s18+s40"
+            ]   
+        }
+    },
+
     "CMSB2023[0]":{
         "read": "polynomial",
         "matrix": "polynomial",

--- a/tests/numerical/numerical_example.py
+++ b/tests/numerical/numerical_example.py
@@ -667,9 +667,23 @@ class AnalysisExample(Experiment):
     ]
 
     def generate_image(self):
-        # TODO: implement
-        logger.error("NotImplementedError: The example of perturbed models is not implemented")
-        return
+        r'''Method that generates an image file with the simulations of self.'''
+        x_axis = array( self.epsilons)
+        data = array([[self.sizes[i]/self.size, dev/self.max_dev ] for i, dev in enumerate(self.deviations)]).transpose()
+        graph = OdeResult(t=x_axis, y=data, success=True, names=["dev/devmax", "num size/size"])
+        fig = create_figure(
+            graph,
+        title = f"Lumping evolution for {str(self.observable) }"
+        )
+        fig.savefig(
+            self.example.image_path(
+                SCRIPT_DIR, self.example.read, self.example.matrix,
+                f"{self.observable_name}#analysis"
+            )
+        )
+        plt.close()
+        # logger.error("NotImplementedError: The example of perturbed models is not implemented")
+        # return
 
     def write_result(self, file: TextIOBase):
         r'''Method that generates a results file with the information of this '''
@@ -1436,8 +1450,13 @@ def __run_analysis(example: Example,
 
         result.time_total = time.time()-ctime
         logger.log(60, f"[run_analysis # {example.name}] Generating output for \n\t{repr(result)}")
-
         result.write_result(output)
+        logger.log(60, f"[run_analysis # {example.name}] Generating images for \n\t{repr(result)}")
+        result.generate_image()
+        logger.log(60, f"[run_analysis # {example.name}] Finished execution for \n\t{repr(result)}")
+
+
+
 
 
 def __run_perturbed():

--- a/tests/numerical/numerical_example.py
+++ b/tests/numerical/numerical_example.py
@@ -1127,6 +1127,7 @@ def run_example(*argv):
     profile: bool = None
     percentage_slope: float | list[float] = None
     epsilons: float | list[float] = None
+    mid_points: int = example.get("mid_points", 50)
     sample_points: int = example.get("sample_points", 50)
     threshold: float = example.get("threshold", 1e-6)
     type_example: str = example.get("type", "slope")
@@ -1227,6 +1228,9 @@ def run_example(*argv):
         elif not len(epsilons) == len(example.observables):
             logger.error(f"[run_example # {example.name}] Epsilons must be a list of length {len(example.observables)} of lists or arbitrary length")
 
+    # if type_example == "analysis":
+        # mid_points = example.get("mid_points", 20 ) if mid_points is None else mid_points
+        
     ## Running the requested example
     with (open(output, "w") if output not in (sys.stdout, sys.stderr) else nullcontext()) as output:
         logger.log(60, f"[run_example # {example.name}] Running example type: {type_example}")
@@ -1238,10 +1242,8 @@ def run_example(*argv):
                 __run_exact(example, read, matrix, observables, timeout, output, None,epsilons,
                             sample_points, threshold, t0, t1, tstep)
             elif type_example == "analysis":
-                __run_analysis(example,
-                               read, matrix, observables, timeout, 
-                               output, 
-                               sample_points,threshold) # mid_points set to default (20)
+                __run_analysis(example = example,
+                               read=read, matrix=matrix, observables=observables,timeout=timeout, output=output, num_points=sample_points, threshold=threshold, mid_points=mid_points)
             elif type_example == "perturbed":
                 __run_perturbed()
             else:
@@ -1415,7 +1417,7 @@ def __run_analysis(example: Example,
     # bound = RRsystem._FODESystem__process_bound(norm_x0, 1e-6)
     ## Gathering data
     for (view_name,observable) in observables.items():
-        logger.log(60, f"[run_analysis # {example.name}] Computing data for {view_name}...")
+        logger.log(60, f"[run_analysis # {example.name}] Computing {mid_points} for {view_name}...")
         ctime = time.time()
         observable_matrix= observable_matrices[view_name]
         max_epsilon, max_deviation = RRsystem.find_maximal_threshold(observable, bound, num_points, threshold, matrix_algorithm=example.matrix);

--- a/tests/numerical/numerical_example.py
+++ b/tests/numerical/numerical_example.py
@@ -828,6 +828,7 @@ class Timeout(object):
 ### SCRIPT METHODS
 ############################################################
 def list_examples(*argv):
+    # TODO: Update this method for analysis type
     r'''List examples in the folder. It allows several arguments.'''
     full = False
     type = ("polynomial", "uncertain", "rational", "sympy")


### PR DESCRIPTION
Added functionality to read files from folder and generate a json file with all the experiments.
Given a folder to read models from, the function `add_examples_in_folder` reads all the folder an generates a .json with experiments. 
- It allows to choose between an analysis and an slope  experiment as default experiment. 
- It is possible to choose the output folder for the experiments
- All `.ode` files should be properly formatted for this functionality to work properly